### PR TITLE
Mle2718 patch set.seed

### DIFF
--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -50,7 +50,7 @@ for(r in 1:nrep){
 
        manage_counter<-0
 
-       #Restore the rng state to the value of oldseed_mproc.  For the same values of r, all the management procedures to start from the same RNG state.  You probably want oldseed_mproc
+       #Restore the rng state to the value of oldseed_mproc.  For the same values of r, all the management procedures to start from the same RNG state.
        .Random.seed<-oldseed_mproc
 
         #the econtype dataframe will pass a few things through to the econ model that govern how fishing is turned on/off when catch limits are reached, which sets of coefficients to use, and which prices to use

--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -43,16 +43,15 @@ top_loop_start<-Sys.time()
 
 #### Top rep Loop ####
 for(r in 1:nrep){
-    # oldseed_mproc <- .Random.seed
+    oldseed_mproc <- .Random.seed
 
   #### Top MP loop ####
   for(m in 1:nrow(mproc)){
 
        manage_counter<-0
 
-       #Restore the rng state.  Depending on whether you use oldseed1 or oldseed2, you'll get different behavior.  oldseed_ALL will force all the replicates to start from the same RNG state.  oldseed_mproc will force all the management procedures to have the same RNG state.  You probably want oldseed_mproc
-       #.Random.seed<-oldseed_ALL
-       # .Random.seed<-oldseed_mproc
+       #Restore the rng state to the value of oldseed_mproc.  For the same values of r, all the management procedures to start from the same RNG state.  You probably want oldseed_mproc
+       .Random.seed<-oldseed_mproc
 
         #the econtype dataframe will pass a few things through to the econ model that govern how fishing is turned on/off when catch limits are reached, which sets of coefficients to use, and which prices to use
         if(mproc$ImplementationClass[m]=="Economic"){

--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -30,9 +30,9 @@ if(runClass != 'HPCC'){
 
 start<-Sys.time()-as.POSIXct("2018-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
 start<-as.double(start)*100
-# set.seed(start)
+set.seed(start)
 
- oldseed_ALL <- .Random.seed
+oldseed_ALL <- .Random.seed
 showProgBar<-TRUE
 ####################End Parameter and storage Setup ####################
   #This depends on mproc, fyear, and nyear. So it should be run *after* it is reset. I could be put in the runSetup.R script. But since I'm  adjusting fyear and nyear temporarily, I need it here (for now).


### PR DESCRIPTION
Handle rng seed properly.

1. Initial random seed set based on clock time.  
2. All simulations with the same replicate number (r) get set to the same initial Random number generator state
