### PR TITLE
add fishmethods package to the pkg list.

### DIFF
--- a/processes/loadLibs.R
+++ b/processes/loadLibs.R
@@ -45,7 +45,7 @@ if(runClass == 'HPCC'){
     sapply(pkg, require, character.only = TRUE)
   }
 
-  pkg<-c("msm", "tmvtnorm", "TMB", "abind", "glue", "tidyverse", "dplyr", "data.table", "ASAPplots","timeSeries","fBasics","fGarch")
+  pkg<-c("msm", "tmvtnorm", "TMB", "abind", "glue", "tidyverse", "dplyr", "data.table", "ASAPplots","fishmethods","timeSeries","fBasics","fGarch")
   check.packages(pkg)
 
   require(msm)


### PR DESCRIPTION
withouth fishmethods in the object pkg, fishmethods will not be automatically installed by the check.packages() function