### PR TITLE
Ml asap

### DIFF
--- a/functions/assessment/get_ASAP.R
+++ b/functions/assessment/get_ASAP.R
@@ -127,14 +127,17 @@ get_ASAP <- function(stock){
 
       tempwd <- getwd()
       setwd(rundir)
-      asapEst<- try(system("singularity exec $WINEIMG wine ASAP3.EXE", wait = TRUE))
-
-      while (!file.exists('asap3.rdat')) {
+      if(runClass =="HPCC"){
+        asapEst<- try(system("singularity exec $WINEIMG wine ASAP3.EXE", wait = TRUE))
+      } else if (runClass =="neptune"){
+        asapEst<- try(system("./ASAP3", wait = TRUE))
+      }
+      while (!file.exists('ASAP3.rdat')) {
         Sys.sleep(1)
       }
 
       # Read in results
-      res <- dget('asap3.rdat')
+      res <- dget('ASAP3.rdat')
       
       # save .Rdata results from each run
       saveRDS(res, file = paste(rundir, '/', stockName, '_', r, '_', y,'.rdat', sep = ''))

--- a/processes/get_runinfo.R
+++ b/processes/get_runinfo.R
@@ -4,7 +4,7 @@
 # Determine what platform the code is running on (Duplicated purposefully
 # in runPre.R for running on HPCC)
 platform <- Sys.info()['sysname']
-
+servername <- Sys.info()['nodename']
 # Determine whether or not this is a run on the HPCC by checking the name of
 # the node
 if(platform == 'Linux'){
@@ -16,6 +16,10 @@ if(platform == 'Linux'){
   # error.
   if(length(evndir) > 0 && evndir == '/lsf/conf'){
     runClass <- 'HPCC'
+  }else if(servername=='neptune'){
+    runClass<-'neptune'
+  }else if(servername=='mlee-linux-pc'){
+    runClass<-'mleeLocal'
   }else{
     runClass <- 'Local'
   }

--- a/processes/runSetup.R
+++ b/processes/runSetup.R
@@ -158,7 +158,7 @@ if(fyear < mxModYrs){
 }
 
 if (platform == 'Linux'){
-  if(!file.exists('../EXE/ASAP3.EXE')){
+  if(!file.exists('../EXE/ASAP3.EXE') & runClass=='HPCC'){
     warning(paste('ASAP3.EXE should be loaded in a directory EXE in the parent',
                'directory of groundfish-MSE -- i.e., you need an EXE',
                'directory in the same directory as Rlib and EXE must contain',
@@ -168,7 +168,20 @@ if (platform == 'Linux'){
   tempwd <- getwd()
   rundir <- paste(tempwd, "/assessment/ASAP/Run", '_', rand, sep = "")
   dir.create(path = rundir)
-  from.path <- paste('../EXE/ASAP3.EXE', sep = "")
+  
+  # setup command to run ASAP. For now, ASAP is located at /net/home2/mlee/admb-12.3/asap3/asap3
+  if(runClass=='neptune'){
+    full.path.to.asap<- "/net/home2/mlee/admb-12.3/ASAP3/ASAP3"
+  } else if(runClass=='mleeLocal'){
+    full.path.to.asap<- "placeholder/path/to/ASAP3"
+  } else if(runClass=='HPCC'){
+    full.path.to.asap<- paste('../EXE/ASAP3.EXE', sep = "")
+  } else{
+    warning(paste('Unknown Linux runClass.',
+                  'You will not be able to find ASAP',
+                  'Modify runSetup.R', sep='\n', immediate.=TRUE))
+  }   
+  from.path <- full.path.to.asap
   to.path   <- paste(rundir, sep= "")
   file.copy(from = from.path, to = to.path)
   


### PR DESCRIPTION


Modify to run a native ASAP3. HPCC runs should not be affected.
What's changed

1. added an extra variable servername <- Sys.info()['nodename'] in getrunInfo.R. I use this to make new values of runClass.
2. runSetup.R has places to specify the path to ASAP3 (linux) or ASAP3.EXE (Linux with WINE). This depends on runClass
3. runSetup.R has a warning message about runClass if it is not set to a few known values.
4. getASAP.R now executes different commands based on runClass.

To run ASAP3 natively in Linux, you must.

1. Get the ASAP3 source code. rename asap3.tpl to ASAP3.tpl
2. Use ADMB to compile it.
3. Update the full.path.to.asap in runSetup.R
4. Update the asapEst in get_ASAP.R

Sorry, I did something wrong in PR #206, I think i either built it on the Econ_only2 branch or pulled Econ_only2 into that branch. And We definitely dont want that now.