### PR TITLE
Mle2718 sum cw and z

### DIFF
--- a/functions/popdy/get_J1Updates.R
+++ b/functions/popdy/get_J1Updates.R
@@ -69,14 +69,7 @@ get_J1Updates <- function(stock){
     # on the recruitment this year
     J1N[y,] <- get_J1Ny(J1Ny0=J1N[y-1,], Zy0=Z[y-1,], R[y])
 
-    # calculate the predicted catch in year y, the catch weight and the
-    # proportions of catch numbers-at-age. Add small number in case F=0
-    CN[y,] <- get_catch(F_full=F_full[y], M=natM[y],
-                        N=J1N[y,], selC=slxC[y,]) + 1e-3
-
-    # get Z for the current year
-    Z[y,] <- F_full[y]*slxC[y,] + natM[y]
-
+    
     # calculate SSB for the current year AEW
 
     SSB_cur[y] <- sum(J1N[y,] * mat[y,] * waa[y,])

--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -118,18 +118,23 @@ for(r in 1:nrep){
           #Add a warning about invalid ImplementationClass
         }
 
-        for(i in 1:nstock){
-          if (y == nyear){
-            stock[[i]] <- get_TermrelError(stock = stock[[i]])
-          }
-          stock[[i]] <- get_fillRepArrays(stock = stock[[i]])
-        }
-      } #End of burn-in loop
+
+      } # End of the if "burn-in period is over and fishery management has started" clause 
+      
       for(i in 1:nstock){
         stock[[i]] <- get_mortality(stock = stock[[i]])
         stock[[i]] <- get_indexData(stock = stock[[i]])
       } #End killing fish loop
-
+      
+      # Store results
+      for(i in 1:nstock){
+        if (y == nyear){
+          stock[[i]] <- get_TermrelError(stock = stock[[i]])
+        }
+        if(y>=fmyearIdx){
+          stock[[i]] <- get_fillRepArrays(stock = stock[[i]])
+        }
+      } 
       end_rng_holder[[yearitercounter]]<-c(r,m,y,yrs[y],.Random.seed)
 
           #Save economic results once in a while to a csv file.


### PR DESCRIPTION
@jerellejesse

Old:
``stock[[i]] <- get_fillRepArrays(stock = stock[[i]])``  is executed *before* sumCW[y] is computed.

New:
``stock[[i]] <- get_fillRepArrays(stock = stock[[i]])``  is executed *after* sumCW[y] is computed.

We could consolidate the loops that begin on lines 124 and 129 but this way is nice because it keeps the "output storage" separate from the rest of the code.

I tested this with both an economic and non-economic model and I believe it works.  

One thing I noticed in some of my sims was that omvalGlobal[[i]]l$sumCW would be NA once in a while. This would happen for the last year.  I *think* this will address that phenomenon.
