### PR TITLE
Readin patch3

### DIFF
--- a/processes/runPost.R
+++ b/processes/runPost.R
@@ -8,8 +8,8 @@ source('processes/identifyResultDirectory.R')
 source('processes/runSetup.R')
 
 
-# Load in the simulation results
-fl <- list.files(file.path(ResultDirectory, 'sim'), full.names=TRUE)
+# Load in the stock-level simulation results
+fl <- list.files(file.path(ResultDirectory, 'sim'), pattern="omvalGlobal", full.names=TRUE)
 
 # load all the functions
 ffiles <- list.files(path='functions/', full.names=TRUE, recursive=TRUE)
@@ -23,6 +23,15 @@ for(i in 1:length(fl)){
   flLst[[i]] <- omvalGlobal
   names(flLst[[i]]) <- names(omvalGlobal)
 }
+
+# Load in the aggregate simulation results
+sl <- list.files(file.path(ResultDirectory, 'sim'), pattern="simlevelresults", full.names=TRUE)
+
+simlevel <-list()
+for(i in 1:length(sl)){
+  simlevel[[i]]<-readRDS(sl[i])
+}
+
 
 for(i in 1:length(flLst[[1]])){
 

--- a/processes/runPost.R
+++ b/processes/runPost.R
@@ -28,10 +28,12 @@ for(i in 1:length(fl)){
 sl <- list.files(file.path(ResultDirectory, 'sim'), pattern="simlevelresults", full.names=TRUE)
 
 simlevel <-list()
-for(i in 1:length(sl)){
-  simlevel[[i]]<-readRDS(sl[i])
-}
 
+if(length(sl)>=1){
+  for(i in 1:length(sl)){
+    simlevel[[i]]<-readRDS(sl[i])
+  }
+}
 
 for(i in 1:length(flLst[[1]])){
 


### PR DESCRIPTION
@jerellejesse -- While also trying to merge these changes using github into EconOnly2, I accidentally did readin_patch3<-EconOnly2. At least I learned that it's easier to do that in the command line.
I've closed #255, because we really don't want to do that anymore. 

I wrapped an if() statement in there. I tested it by renaming my ``simlevelresults2022-09-28_153947_1072.Rds`` file to something that doesn't match the pattern. 