### PR TITLE
properly set seed

### DIFF
--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -28,8 +28,7 @@ if(runClass != 'HPCC'){
 #set the rng state based on system time.  Store the random state.
 # if we use a plain old date (seconds since Jan 1, 1970), the number is actually too large, but we can just rebase to seconds since Jan 1, 2018.
 
-start<-Sys.time()-as.POSIXct("2018-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
-start<-as.double(start)*100
+start<-difftime(Sys.time(), as.POSIXct("2018-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"), units="secs")
 set.seed(start)
 
 oldseed_ALL <- .Random.seed


### PR DESCRIPTION
the argument of set.seed() is an integer (and quietly converted to an integer). 
The previous way of setting a seed 
```
start<-Sys.time()-as.POSIXct("2018-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
start<-as.double(start)*100 
```
was not necessarily producing integers. It was producing days elapsed from Jan 1, 2018, multiplied by 100.  This isn't good enough to ensure that different model runs start at a different value. 