### PR TITLE
explicitly set the dimension to abind along.

### DIFF
--- a/functions/get_simcat.R
+++ b/functions/get_simcat.R
@@ -1,23 +1,25 @@
 
 
 
-# Function to concatonate multiple simulation repetitions (i.e., from
+# Function to concatenate multiple simulation repetitions (i.e., from
 # running on the hpcc), into a single list output for analysis. simcat
-# refers to concatonating the results from the simulations.
+# refers to concatenating the results from the simulations.
 # 
 # x: list of results. What you do is combine the Rdata files from the different
 #    simulation runs into a single list which is the input x.
+# along_dim= the dimension of the containers that you want to concatenate. see get_containers()
+#  1 = replicate and 2=mproc
 
 
 
-get_simcat <- function(x){
+get_simcat <- function(x, along_dim=1){
   
   out <- list()
   for(i in 1:length(x[[1]])){
     
     z <- lapply(x, '[[', i)
     
-    out[[i]] <- do.call(abind, list(z, along=1))
+    out[[i]] <- do.call(abind, list(z, along=along_dim))
     
   }
   

--- a/processes/runPost.R
+++ b/processes/runPost.R
@@ -53,7 +53,7 @@ traj_these <- c("SSB", "SSB_cur", "R", "F_full", "sumCW",
 
 for(i in 1:length(flLst[[1]])){
 
-  omval <- get_simcat(x=lapply(flLst, '[[', i))
+  omval <- get_simcat(x=lapply(flLst, '[[', i ), along_dim=1)
   names(omval) <- names(flLst[[1]][[i]])
   stknm <- names(flLst[[1]])[i]
   


### PR DESCRIPTION
modify get_simcat() to take an extra argument. Default is to concatenate along the first dimension, which is replicates.  Can also concatenate along dimension 2, which is mproc. This would be useful if you ran a model with 1 mproc file and then ran it again with another, but wanted the results to be in the same place. 

A problem is that you have to figure out which management procedure corresponds to which entry.  